### PR TITLE
Исправлена ошибка при первом (и последующих) запуске gm скрипта.

### DIFF
--- a/gm/apiwrapper.js
+++ b/gm/apiwrapper.js
@@ -35,11 +35,21 @@ This file is part of CHAS-CORRECT.
    вместе с этой программой. Если это не так, см.
    <http://www.gnu.org/licenses/>.)
 */
+'use strict';
 
 var storageWrapper={
 	///Обёртка над хранилищем, в данном случае - GreaseMonkey
 	getKey: function(key,defaultValue){
-		return JSON.parse(GM_getValue(key,defaultValue)) || defaultValue;
+		try {
+			var val = GM_getValue(key);
+			if (val === undefined) {
+				return defaultValue;
+			} else {
+				return JSON.parse(val);
+			};
+		} catch (e) { 
+			return defaultValue 
+		};
 	},
 	setKey: function(key,value){
 		GM_setValue(key,JSON.stringify(value));

--- a/gm/userscript.meta
+++ b/gm/userscript.meta
@@ -1,9 +1,11 @@
-// ==UserScript==
+﻿// ==UserScript==
 // @name          ЧАС-коррект
 // @namespace     http://www.example.com/gmscripts
 // @description   Исправление наиболее частотных ошибок на просматриваемых страницах
 // @include       http://*
 // @include       https://*
 // @version       0.2.0.4
+// @grant	  GM_getValue
+// @grant	  GM_setValue
 // @license       GNU GPLv3
 // ==/UserScript==


### PR DESCRIPTION
Исправлена ошибка при первом (и последующих) запуске gm скрипта.
Даны необходимые разрешения на внутренние методы greasemonkey.

Метод storageWrapper.getKey падает, если в хранилище нет указанного ключа.
Тесты приложу при необходимости